### PR TITLE
Fix JSDom 11.12 dependency issue

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,10 @@
 {
   "name": "donate-period",
   "private": true,
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  },
   "dependencies": {
     "react": "^16.4.1",
     "react-dom": "^16.4.1",


### PR DESCRIPTION
* Causing an error: SecurityError: localStorage is not available for
opaque origins
* Fix as per: https://github.com/facebook/jest/issues/6766 with jest
configuration specified